### PR TITLE
feat: extract DOI from ee field before calling external APIs

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -935,9 +935,9 @@ def _extract_doi_from_ee(ee: str) -> str:
     for prefix in doi_prefixes:
         if ee.lower().startswith(prefix.lower()):
             doi = ee[len(prefix):].strip()
-            doi_without_params = doi.split("?", 1)[0].split("#", 1)[0]
-            doi = doi_without_params.rstrip(".,;:)]}>\"'")
-            if re.match(r"^10\.\S+/\S+$", doi):
+            doi_cleaned = doi.split("?", 1)[0].split("#", 1)[0]
+            doi = doi_cleaned.rstrip(".,;:)]}>\"'")
+            if re.match(r"^10\.[0-9.]+/[^\s]+$", doi):
                 return doi
     return ""
 

--- a/src/utils.py
+++ b/src/utils.py
@@ -915,10 +915,41 @@ def _fetch_dblp_doi(key: str, last_request_time: float, min_interval: float = 1.
     return None, None, last_request_time
 
 
+def _extract_doi_from_ee(ee: str) -> str:
+    """从 ee 超链接中提取 DOI，若非 DOI 格式则返回空字符串。
+
+    支持的 DOI 链接格式：
+      - https://doi.org/10.xxxx/...
+      - http://doi.org/10.xxxx/...
+      - https://dx.doi.org/10.xxxx/...
+      - http://dx.doi.org/10.xxxx/...
+      - doi:10.xxxx/...
+    """
+    if not ee:
+        return ""
+    ee = ee.strip()
+    # 匹配常见 DOI URL 前缀并提取后续部分
+    doi_prefixes = [
+        "https://doi.org/",
+        "http://doi.org/",
+        "https://dx.doi.org/",
+        "http://dx.doi.org/",
+        "doi:",
+    ]
+    for prefix in doi_prefixes:
+        if ee.lower().startswith(prefix.lower()):
+            doi = ee[len(prefix):].strip()
+            # 简单校验：DOI 通常以 10. 开头
+            if doi.startswith("10."):
+                return doi
+    return ""
+
+
 def fetch_doi_for_papers(papers, sleep_sec=2.0, max_retries=4, contact_email="", overwrite=False):
     """为论文列表批量获取 DOI（默认仅补充缺失 DOI 的条目）。
 
     查询优先级：
+      0. ee 字段直接提取（若 ee 为 DOI 格式，零成本获取）
       1. DBLP API（通过论文 key 重新查询，最权威）
       2. Crossref 搜索 API（通过标题搜索）
       3. Semantic Scholar 搜索 API（通过标题搜索）
@@ -959,8 +990,15 @@ def fetch_doi_for_papers(papers, sleep_sec=2.0, max_retries=4, contact_email="",
         logger.info(f"[{i}/{len(papers)}] Fetching DOI: {title[:60]}...")
         doi = None
 
-        # 1. 优先 DBLP API（通过 key 重新查询，最权威）
-        if key:
+        # 0. 优先从 ee 字段直接提取 DOI（零成本）
+        ee = (paper.get("ee") or "").strip()
+        if ee:
+            doi = _extract_doi_from_ee(ee)
+            if doi:
+                logger.info(f"  -> Extracted DOI from ee: {doi}")
+
+        # 1. ee 中无 DOI，则优先查询 DBLP API（通过 key 重新查询，最权威）
+        if not doi and key:
             doi, api_title, last_request_time["dblp"] = _fetch_dblp_doi(
                 key, last_request_time["dblp"], min_interval=sleep_sec, max_retries=max_retries
             )

--- a/src/utils.py
+++ b/src/utils.py
@@ -935,9 +935,9 @@ def _extract_doi_from_ee(ee: str) -> str:
     for prefix in doi_prefixes:
         if ee.lower().startswith(prefix.lower()):
             doi = ee[len(prefix):].strip()
-            doi = doi.split("?", 1)[0].split("#", 1)[0].rstrip(".,;:)]}>\"'")
-            # 简单校验：DOI 通常以 10. 开头
-            if doi.startswith("10.") and re.match(r"^10\.\S+/\S+$", doi):
+            doi_without_params = doi.split("?", 1)[0].split("#", 1)[0]
+            doi = doi_without_params.rstrip(".,;:)]}>\"'")
+            if re.match(r"^10\.\S+/\S+$", doi):
                 return doi
     return ""
 

--- a/src/utils.py
+++ b/src/utils.py
@@ -17,6 +17,8 @@ DBLP_SEARCH_RETRY_BASE_SECONDS = 4.0
 DBLP_SEARCH_RETRY_CAP_SECONDS = 120.0
 DBLP_SEARCH_JITTER_MIN_SECONDS = 0.5
 DBLP_SEARCH_JITTER_MAX_SECONDS = 2.5
+DOI_PATTERN = re.compile(r"^10\.[0-9.]+/[^\s]+$")
+DOI_TRAILING_PUNCTUATION = ".,;:)]}>\"'"
 
 
 def init_log():
@@ -936,8 +938,8 @@ def _extract_doi_from_ee(ee: str) -> str:
         if ee.lower().startswith(prefix.lower()):
             doi = ee[len(prefix):].strip()
             doi_cleaned = doi.split("?", 1)[0].split("#", 1)[0]
-            doi = doi_cleaned.rstrip(".,;:)]}>\"'")
-            if re.match(r"^10\.[0-9.]+/[^\s]+$", doi):
+            doi = doi_cleaned.rstrip(DOI_TRAILING_PUNCTUATION)
+            if DOI_PATTERN.match(doi):
                 return doi
     return ""
 

--- a/src/utils.py
+++ b/src/utils.py
@@ -891,15 +891,11 @@ def _fetch_dblp_doi(key: str, last_request_time: float, min_interval: float = 1.
             if doi_elem is not None and doi_elem.text:
                 doi = doi_elem.text.strip()
 
-            # 2. 若 <doi> 不存在，尝试从 <ee> 中提取 https://doi.org/... 链接
+            # 2. 若 <doi> 不存在，尝试从 <ee> 中提取 DOI
             if not doi:
                 ee_elem = record.find("ee")
                 if ee_elem is not None and ee_elem.text:
-                    ee = ee_elem.text.strip()
-                    if ee.startswith("https://doi.org/"):
-                        doi = ee[len("https://doi.org/"):].strip()
-                    elif ee.startswith("http://doi.org/"):
-                        doi = ee[len("http://doi.org/"):].strip()
+                    doi = _extract_doi_from_ee(ee_elem.text.strip())
 
             if doi:
                 return doi, api_title, last_request_time
@@ -939,8 +935,9 @@ def _extract_doi_from_ee(ee: str) -> str:
     for prefix in doi_prefixes:
         if ee.lower().startswith(prefix.lower()):
             doi = ee[len(prefix):].strip()
+            doi = doi.split("?", 1)[0].split("#", 1)[0].rstrip(".,;:)]}>\"'")
             # 简单校验：DOI 通常以 10. 开头
-            if doi.startswith("10."):
+            if doi.startswith("10.") and re.match(r"^10\.\S+/\S+$", doi):
                 return doi
     return ""
 


### PR DESCRIPTION
Add _extract_doi_from_ee() to parse DOI from common ee URL patterns (https://doi.org/, https://dx.doi.org/, doi:, etc.) as step 0 in fetch_doi_for_papers(), skipping external API calls when DOI is already present in the ee link.